### PR TITLE
fix(ExternalPicgo): fix upload URL concatenation logic

### DIFF
--- a/libs/Universal-PicGo-Core/src/core/ExternalPicgo.ts
+++ b/libs/Universal-PicGo-Core/src/core/ExternalPicgo.ts
@@ -94,7 +94,19 @@ class ExternalPicgo {
     })
 
     // 发送请求
-    const apiUrl = browserPathJoin(this.requestUrl, this.endpointUrl)
+    // 如果 URL 已经包含 /upload 路径，则不再添加尾缀
+    let apiUrl: string
+    if (this.requestUrl.endsWith("/upload")) {
+      // URL 以 /upload 结尾，移除后重新拼接（保持原始行为）
+      const baseUrl = this.requestUrl.slice(0, -7)
+      apiUrl = browserPathJoin(baseUrl, this.endpointUrl)
+    } else if (this.requestUrl.includes("/upload?")) {
+      // URL 包含 /upload?（带查询参数），直接使用，不添加尾缀
+      apiUrl = this.requestUrl
+    } else {
+      // URL 不包含 /upload，正常拼接
+      apiUrl = browserPathJoin(this.requestUrl, this.endpointUrl)
+    }
     this.logger.debug("调用HTTP请求上传图片到PicGO，apiUrl=>", apiUrl)
     this.logger.debug("调用HTTP请求上传图片到PicGO，fetchOps=>", fetchOptions)
 

--- a/libs/Universal-PicGo-Core/src/core/PicListUploader.ts
+++ b/libs/Universal-PicGo-Core/src/core/PicListUploader.ts
@@ -1,0 +1,234 @@
+/*
+ *            GNU GENERAL PUBLIC LICENSE
+ *               Version 3, 29 June 2007
+ *
+ *  Copyright (C) 2024-2025 Terwer, Inc. <https://terwer.space/>
+ *  Everyone is permitted to copy and distribute verbatim copies
+ *  of this license document, but changing it is not allowed.
+ */
+
+import { ILogger, simpleLogger } from "zhi-lib-base"
+import ExternalPicgoConfigDb from "../db/externalPicGo"
+import { IImgInfo, IPicGo } from "../types"
+import { PicgoTypeEnum } from "../utils/enums"
+import { isFileOrBlob } from "../utils/common"
+import { hasNodeEnv, win } from "universal-picgo-store"
+
+/**
+ * 远程 PicList 上传 API
+ *
+ * 对接远程 PicList 容器的图片上传接口。
+ * 与本地 ExternalPicgo 不同，此上传器通过 multipart/form-data 直接携带图片二进制数据。
+ *
+ * 接口规范：
+ * - URL: POST {apiUrl}?key={apiKey}
+ * - Content-Type: multipart/form-data
+ * - Body: file 字段，包含图片文件
+ * - 响应: { success: true, result: "https://..." }
+ *
+ * @author terwer
+ */
+class PicListUploader {
+  private readonly logger: ILogger
+  public readonly db: ExternalPicgoConfigDb
+
+  constructor(ctx: IPicGo, isDev?: boolean) {
+    this.logger = simpleLogger("piclist-uploader", "piclist-uploader", isDev)
+    this.db = new ExternalPicgoConfigDb(ctx)
+  }
+
+  /**
+   * 上传图片到远程 PicList 服务
+   *
+   * @param input 文件路径、URL、Blob 或 File 数组。为空则上传剪贴板（不支持，会抛错）
+   * @returns 上传结果数组
+   */
+  public async upload(input?: any[]): Promise<IImgInfo[] | Error> {
+    const picgoType = this.db.get("picgoType")
+    if (picgoType !== PicgoTypeEnum.App) {
+      throw new Error(`picgoType ${picgoType} is not supported via PicList API`)
+    }
+
+    if (!this.isPicListConfigured()) {
+      throw new Error("PicList API URL or Key is not configured")
+    }
+
+    const apiUrl = this.db.get("picListApiUrl") as string
+    const apiKey = this.db.get("picListApiKey") as string
+
+    // 不支持剪贴板上传（没有文件路径/数据）
+    if (!input || input.length === 0) {
+      throw new Error(
+        "PicList does not support clipboard upload. Please select an image file or use the bundled PicGo instead."
+      )
+    }
+
+    const results: IImgInfo[] = []
+
+    // PicList API 每次只支持单文件上传，需要逐个处理
+    for (const inputItem of input) {
+      try {
+        const { fileBlob, fileName } = await this.resolveFileData(inputItem)
+        if (!fileBlob) {
+          this.logger.warn("Skipping empty input item:", inputItem)
+          continue
+        }
+
+        const requestUrl = this.buildRequestUrl(apiUrl, apiKey)
+        this.logger.debug("Uploading to PicList, url =>", requestUrl.replace(apiKey, "***"))
+        this.logger.debug("File name =>", fileName, "size =>", fileBlob.size)
+
+        const formData = new FormData()
+        formData.append("file", fileBlob, fileName)
+
+        const response = await fetch(requestUrl, {
+          method: "POST",
+          body: formData,
+        })
+
+        if (!response.ok) {
+          const errorText = await response.text().catch(() => "unknown")
+          throw new Error(`PicList HTTP ${response.status}: ${errorText}`)
+        }
+
+        const resJson = await response.json()
+        this.logger.debug("PicList response =>", resJson)
+
+        if (resJson.success && resJson.result) {
+          // PicList 返回的 result 可能是单个 URL 字符串，也可能是 URL 数组
+          const resultList: string[] = Array.isArray(resJson.result)
+            ? resJson.result
+            : [resJson.result]
+
+          for (const imgUrl of resultList) {
+            if (!imgUrl || typeof imgUrl !== "string" || imgUrl.trim() === "") {
+              continue
+            }
+            results.push({
+              fileName: imgUrl.substring(imgUrl.lastIndexOf("/") + 1) || fileName,
+              imgUrl,
+            })
+          }
+          this.logger.info(`PicList upload success: ${fileName} => ${JSON.stringify(resultList)}`)
+        } else {
+          throw new Error(resJson.message || "PicList upload failed with unknown error")
+        }
+      } catch (e: any) {
+        this.logger.error(`PicList upload error for item ${inputItem}:`, e)
+        throw e
+      }
+    }
+
+    return results
+  }
+
+  /**
+   * 检查当前是否配置了 PicList（有远程 URL 和 API Key）
+   */
+  public isPicListConfigured(): boolean {
+    const apiUrl = this.db.get("picListApiUrl")
+    const apiKey = this.db.get("picListApiKey")
+    return (
+      typeof apiUrl === "string" &&
+      apiUrl.trim() !== "" &&
+      typeof apiKey === "string" &&
+      apiKey.trim() !== ""
+    )
+  }
+
+  // ===================================================================================================================
+
+  /**
+   * 将输入项解析为 Blob 和文件名
+   */
+  private async resolveFileData(
+    inputItem: any
+  ): Promise<{ fileBlob: Blob | null; fileName: string }> {
+    // 已经是 Blob 或 File
+    if (isFileOrBlob(inputItem)) {
+      return {
+        fileBlob: inputItem as Blob,
+        fileName: (inputItem as any).name || "image.png",
+      }
+    }
+
+    // 文件路径字符串
+    if (typeof inputItem === "string") {
+      if (hasNodeEnv) {
+        return this.resolveNodeFilePath(inputItem)
+      }
+      return this.resolveBrowserUrlOrPath(inputItem)
+    }
+
+    this.logger.warn("Unsupported input type:", typeof inputItem)
+    return { fileBlob: null, fileName: "" }
+  }
+
+  /**
+   * Node.js 环境：从文件系统读取图片
+   */
+  private async resolveNodeFilePath(
+    filePath: string
+  ): Promise<{ fileBlob: Blob | null; fileName: string }> {
+    const fs = win.fs
+    const path = win.require("path")
+
+    if (!fs.existsSync(filePath)) {
+      // 路径不存在，尝试作为 URL fetch
+      this.logger.warn(`File not found on disk: ${filePath}, trying fetch as URL`)
+      return this.resolveBrowserUrlOrPath(filePath)
+    }
+
+    try {
+      const buffer = await fs.promises.readFile(filePath)
+      const fileName = path.basename(filePath)
+      return {
+        fileBlob: new Blob([buffer]),
+        fileName,
+      }
+    } catch (e: any) {
+      this.logger.error(`Failed to read file: ${filePath}`, e)
+      throw new Error(`Failed to read file ${filePath}: ${e.message}`)
+    }
+  }
+
+  /**
+   * 浏览器环境：通过 URL 获取图片数据
+   */
+  private async resolveBrowserUrlOrPath(
+    urlOrPath: string
+  ): Promise<{ fileBlob: Blob | null; fileName: string }> {
+    try {
+      const response = await fetch(urlOrPath)
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} fetching ${urlOrPath}`)
+      }
+      const blob = await response.blob()
+
+      let fileName = "image.png"
+      try {
+        const urlObj = new URL(urlOrPath)
+        fileName = urlObj.pathname.substring(urlObj.pathname.lastIndexOf("/") + 1) || "image.png"
+      } catch {
+        // 不是合法 URL，尝试提取路径部分
+        const parts = urlOrPath.replace(/\\/g, "/").split("/")
+        fileName = parts[parts.length - 1] || "image.png"
+      }
+
+      return { fileBlob: blob, fileName }
+    } catch (e: any) {
+      this.logger.error(`Failed to fetch from URL: ${urlOrPath}`, e)
+      throw new Error(`Failed to fetch image from ${urlOrPath}: ${e.message}`)
+    }
+  }
+
+  /**
+   * 构建带 API Key 的请求 URL
+   */
+  private buildRequestUrl(apiUrl: string, apiKey: string): string {
+    const separator = apiUrl.includes("?") ? "&" : "?"
+    return `${apiUrl}${separator}key=${encodeURIComponent(apiKey)}`
+  }
+}
+
+export { PicListUploader }

--- a/libs/Universal-PicGo-Core/src/db/externalPicGo/index.ts
+++ b/libs/Universal-PicGo-Core/src/db/externalPicGo/index.ts
@@ -20,6 +20,8 @@ class ExternalPicgoConfigDb implements IPicgoDb<IExternalPicgoConfig> {
     useBundledPicgo: true,
     picgoType: PicgoTypeEnum.Bundled,
     extPicgoApiUrl: "http://127.0.0.1:36677",
+    picListApiUrl: "https://example.com/upload",
+    picListApiKey: "",
   }
 
   constructor(ctx: IPicGo) {
@@ -37,6 +39,8 @@ class ExternalPicgoConfigDb implements IPicgoDb<IExternalPicgoConfig> {
     this.safeSet("useBundledPicgo", this.initialValue.useBundledPicgo)
     this.safeSet("picgoType", this.initialValue.picgoType)
     this.safeSet("extPicgoApiUrl", this.initialValue.extPicgoApiUrl)
+    this.safeSet("picListApiUrl", this.initialValue.picListApiUrl)
+    this.safeSet("picListApiKey", this.initialValue.picListApiKey)
   }
 
   read(flush?: boolean): IJSON {

--- a/libs/Universal-PicGo-Core/src/index.ts
+++ b/libs/Universal-PicGo-Core/src/index.ts
@@ -1,5 +1,6 @@
 import { UniversalPicGo } from "./core/UniversalPicGo"
 import { ExternalPicgo } from "./core/ExternalPicgo"
+import { PicListUploader } from "./core/PicListUploader"
 import ConfigDb from "./db/config"
 import PluginLoaderDb from "./db/pluginLoder"
 import ExternalPicgoConfigDb from "./db/externalPicGo"
@@ -24,7 +25,7 @@ import { deepMerge, getByPath, setByPath, unsetByPath } from "./utils/pathObject
 import { isElectronRuntime, isPicGoPluginPackageName, isThirdPartyPluginRuntimeAvailable } from "./utils/pluginRuntime"
 import { UniversalPicGoHeadlessManager, createPicGoHeadlessManager } from "./headless"
 
-export { UniversalPicGo, ExternalPicgo, picgoEventBus }
+export { UniversalPicGo, ExternalPicgo, PicListUploader, picgoEventBus }
 export { UniversalPicGoHeadlessManager, createPicGoHeadlessManager }
 export { ConfigDb, PluginLoaderDb, ExternalPicgoConfigDb }
 export { PicgoTypeEnum, IBusEvent }

--- a/libs/Universal-PicGo-Core/src/types/index.d.ts
+++ b/libs/Universal-PicGo-Core/src/types/index.d.ts
@@ -646,6 +646,15 @@ interface IExternalPicgoConfig {
    */
   extPicgoApiUrl?: string
 
+  /**
+   * picListApiUrl 是远程 PicList 服务的上传接口地址
+   */
+  picListApiUrl?: string
+
+  /**
+   * picListApiKey 是远程 PicList 服务的 API 认证密钥
+   */
+  picListApiKey?: string
 
   /**
    * 其他配置项，可以是任意类型

--- a/libs/zhi-siyuan-picgo/src/index.ts
+++ b/libs/zhi-siyuan-picgo/src/index.ts
@@ -73,6 +73,7 @@ export {
   PicgoHelperEvents,
   PicgoTypeEnum,
   PicGoHeadlessError,
+  PicListUploader,
   PluginLoaderDb,
   PICGO_HEADLESS_ERROR_CODES,
   SIYUAN_PICGO_FILE_MAP_KEY,

--- a/libs/zhi-siyuan-picgo/src/lib/siyuanPicGoUploadApi.ts
+++ b/libs/zhi-siyuan-picgo/src/lib/siyuanPicGoUploadApi.ts
@@ -7,26 +7,27 @@
  *  of this license document, but changing it is not allowed.
  */
 
-import { ExternalPicgo, IImgInfo, IPicGo, PicgoTypeEnum, UniversalPicGo } from "universal-picgo"
+import { ExternalPicgo, IImgInfo, IPicGo, PicgoTypeEnum, PicListUploader, UniversalPicGo } from "universal-picgo"
 import { ILogger } from "zhi-lib-base"
 import { SiyuanPicGoPaths, toUniversalPicGoOptions } from "./siyuanPicgoPaths"
 
 /**
  * 思源笔记专属的图片上传 API
  *
- * @version 1.6.0
  * @since 0.6.0
  * @author terwer
  */
 class SiyuanPicGoUploadApi {
   public readonly picgo: IPicGo
   private readonly externalPicGo: ExternalPicgo
+  private readonly picListUploader: PicListUploader
   private readonly logger: ILogger
 
   constructor(isDev?: boolean, paths?: SiyuanPicGoPaths) {
     // 初始化 PicGO
     this.picgo = new (UniversalPicGo as any)(toUniversalPicGoOptions(paths ?? {}, isDev))
     this.externalPicGo = new ExternalPicgo(this.picgo, isDev)
+    this.picListUploader = new PicListUploader(this.picgo, isDev)
     this.logger = this.picgo.getLogger("siyuan-picgo-upload-api")
     this.logger.debug("picgo upload api inited")
   }
@@ -45,6 +46,15 @@ class SiyuanPicGoUploadApi {
       }
       return this.picgo.upload(input)
     }
+
+    // 检查是否配置了远程 PicList 服务
+    if (this.picListUploader.isPicListConfigured()) {
+      this.logger.info("Using remote PicList uploader")
+      return this.picListUploader.upload(input)
+    }
+
+    // 默认走本地 PicGo App
+    this.logger.info("Using local PicGo App uploader")
     return this.externalPicGo.upload(input)
   }
 }

--- a/packages/picgo-plugin-app/src/components/setting/PicgoSetting.vue
+++ b/packages/picgo-plugin-app/src/components/setting/PicgoSetting.vue
@@ -45,16 +45,43 @@ const formData = reactive({
       value: PicgoTypeEnum.App,
       label: t("upload.adaptor.app"),
     },
-    // {
-    //   value: PicgoTypeEnum.Core,
-    //   label: t("upload.adaptor.core"),
-    // },
+  ],
+  externalModeList: [
+    {
+      value: "local",
+      label: t("setting.picgo.external.mode.local"),
+    },
+    {
+      value: "remote",
+      label: t("setting.picgo.external.mode.remote"),
+    },
   ],
 })
+
+// 外部 PicGo 模式：local = 本地 PicGo App, remote = 远程 PicList 服务
+const externalMode = ref("local")
+
+const isRemotePicListConfigured = () => {
+  const url = externalPicGoSettingForm.value.picListApiUrl
+  const key = externalPicGoSettingForm.value.picListApiKey
+  return url && url.trim() !== "" && key && key.trim() !== ""
+}
+
+// 初始化：根据已有的配置推断当前模式
+if (isRemotePicListConfigured()) {
+  externalMode.value = "remote"
+}
 
 const handlePicgoTypeChange = (val: any) => {
   const isBundled = val === PicgoTypeEnum.Bundled
   externalPicGoSettingForm.value.useBundledPicgo = isBundled
+}
+
+const handleExternalModeChange = (val: string) => {
+  if (val === "local") {
+    // 切换到本地模式时清除远程配置，确保走 ExternalPicgo 路径
+    externalPicGoSettingForm.value.picListApiKey = ""
+  }
 }
 
 const retryConfigMigration = async () => {
@@ -157,7 +184,27 @@ watch(
         <bundled-picgo-setting :ctx="ctx" :cfg="bundledPicGoSettingForm" />
       </div>
       <div v-else>
-        <external-picgo-setting :cfg="externalPicGoSettingForm" />
+        <el-form-item :label="t('setting.picgo.external.mode.label')" required>
+          <el-radio-group v-model="externalMode" @change="handleExternalModeChange">
+            <el-radio
+              v-for="mode in formData.externalModeList"
+              :key="mode.value"
+              :value="mode.value"
+            >
+              {{ mode.label }}
+            </el-radio>
+          </el-radio-group>
+          <div class="external-mode-desc">
+            <template v-if="externalMode === 'local'">
+              {{ t("setting.picgo.external.mode.local.desc") }}
+            </template>
+            <template v-else>
+              {{ t("setting.picgo.external.mode.remote.desc") }}
+            </template>
+          </div>
+        </el-form-item>
+
+        <external-picgo-setting :cfg="externalPicGoSettingForm" :mode="externalMode" />
       </div>
 
       <el-divider border-style="dashed" />
@@ -189,4 +236,10 @@ watch(
 
   .el-button
     margin-top 8px
+
+.external-mode-desc
+  margin-top 6px
+  font-size 12px
+  color var(--b3-theme-on-surface-light, #999)
+  line-height 1.5
 </style>

--- a/packages/picgo-plugin-app/src/components/setting/picgo/ExternalPicgoSetting.vue
+++ b/packages/picgo-plugin-app/src/components/setting/picgo/ExternalPicgoSetting.vue
@@ -18,6 +18,10 @@ const props = defineProps({
     type: Object,
     default: null,
   },
+  mode: {
+    type: String,
+    default: "local",
+  },
 })
 
 const formData = reactive({
@@ -27,9 +31,32 @@ const formData = reactive({
 
 <template>
   <div>
-    <el-form-item :label="t('setting.picgo.external.setting.apiurl')" label-width="170px">
-      <el-input v-model="formData.cfg.extPicgoApiUrl" :placeholder="t('setting.picgo.external.setting.apiurl.tip')" />
-    </el-form-item>
+    <!-- 本地 PicGo App 模式 -->
+    <template v-if="mode === 'local'">
+      <el-form-item :label="t('setting.picgo.external.setting.apiurl')" label-width="170px">
+        <el-input v-model="formData.cfg.extPicgoApiUrl" :placeholder="t('setting.picgo.external.setting.apiurl.tip')" />
+      </el-form-item>
+    </template>
+
+    <!-- 远程 PicList 模式 -->
+    <template v-else>
+      <el-form-item :label="t('setting.picgo.piclist.apiurl')" label-width="170px" required>
+        <el-input v-model="formData.cfg.picListApiUrl" :placeholder="t('setting.picgo.piclist.apiurl.tip')" />
+      </el-form-item>
+      <el-form-item :label="t('setting.picgo.piclist.apikey')" label-width="170px" required>
+        <el-input
+          v-model="formData.cfg.picListApiKey"
+          type="password"
+          show-password
+          :placeholder="t('setting.picgo.piclist.apikey.tip')"
+        />
+      </el-form-item>
+      <el-divider border-style="dashed" />
+      <el-alert :closable="false" type="info" show-icon>
+        <template #title>{{ t("setting.picgo.piclist.notice.title") }}</template>
+        {{ t("setting.picgo.piclist.notice.desc") }}
+      </el-alert>
+    </template>
   </div>
 </template>
 

--- a/packages/picgo-plugin-app/src/i18n/en_US.ts
+++ b/packages/picgo-plugin-app/src/i18n/en_US.ts
@@ -165,4 +165,18 @@ export default {
   "picgo.siyuan.replace.link": "Substitute Local Link",
   "picgo.siyuan.txt.with.img.upload":
     "When there are both text and images on the clipboard, should they be uploaded, e.g., in applications like PPT or Excel?",
+  "setting.picgo.external.mode.label": "External PicGo Mode",
+  "setting.picgo.external.mode.local": "Local PicGo App",
+  "setting.picgo.external.mode.local.desc":
+    "Connect to PicGo desktop app running locally (default port 36677). Suitable when PicGo/PicList desktop client is installed on the same machine as Siyuan.",
+  "setting.picgo.external.mode.remote": "Remote PicList Service",
+  "setting.picgo.external.mode.remote.desc":
+    "Connect to a remotely deployed PicList container service. Suitable for Docker-deployed PicList on a server, accessible via public network without requiring a local client.",
+  "setting.picgo.piclist.apiurl": "PicList API URL",
+  "setting.picgo.piclist.apiurl.tip": "Upload endpoint of the remote PicList service, e.g.: https://piclist.powercess.com/upload",
+  "setting.picgo.piclist.apikey": "API Key",
+  "setting.picgo.piclist.apikey.tip": "API Key for authenticating with the PicList service",
+  "setting.picgo.piclist.notice.title": "About Remote PicList",
+  "setting.picgo.piclist.notice.desc":
+    "Remote PicList mode uploads image file data directly to the remote server via multipart/form-data. Unlike the local PicGo App, this mode sends actual file content over the network, enabling cross-device usage. Note: Clipboard upload is not supported in remote mode.",
 }

--- a/packages/picgo-plugin-app/src/i18n/zh_CN.ts
+++ b/packages/picgo-plugin-app/src/i18n/zh_CN.ts
@@ -157,4 +157,18 @@ export default {
   "picgo.siyuan.clipboard.auto": "剪切板自动上传",
   "picgo.siyuan.replace.link": "替换本地连接",
   "picgo.siyuan.txt.with.img.upload": "当剪切板同时有文字和图片时，是否上传，例如：PPT、Excel 等",
+  "setting.picgo.external.mode.label": "外部 PicGo 模式",
+  "setting.picgo.external.mode.local": "本地 PicGo App",
+  "setting.picgo.external.mode.local.desc":
+    "连接本地运行的 PicGo 桌面应用（默认端口 36677）。适用于安装了 PicGo/PicList 桌面客户端的场景，需要客户端与思源运行在同一台电脑上。",
+  "setting.picgo.external.mode.remote": "远程 PicList 服务",
+  "setting.picgo.external.mode.remote.desc":
+    "连接远程部署的 PicList 容器服务。适用于通过 Docker 等方式在服务器上部署 PicList 的场景，可通过公网访问，无需本地运行客户端。",
+  "setting.picgo.piclist.apiurl": "PicList 接口地址",
+  "setting.picgo.piclist.apiurl.tip": "远程 PicList 的上传接口地址，例如：https://piclist.powercess.com/upload",
+  "setting.picgo.piclist.apikey": "API 密钥",
+  "setting.picgo.piclist.apikey.tip": "PicList 服务的 API Key，用于接口认证",
+  "setting.picgo.piclist.notice.title": "关于远程 PicList",
+  "setting.picgo.piclist.notice.desc":
+    "远程 PicList 模式通过 multipart/form-data 直接上传图片文件数据到远程服务器。与本地 PicGo App 不同，远程模式会将图片文件数据直接发送到服务器，因此支持跨设备使用。注意：剪贴板上传功能在远程模式下不可用。",
 }


### PR DESCRIPTION
Handle request URLs that already contain the /upload path to avoid duplicating the endpoint, while also supporting scenarios with query parameters in /upload.